### PR TITLE
Ensure vignette is built when installed from GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ R package for benchmarking single cell analysis methods, primarily inspired by t
 
 ```r
 if (!require(remotes)) install.packages("remotes")
-remotes::install_github("shians/CellBench", ref = "R-3.5")
+remotes::install_github("shians/CellBench", ref = "R-3.5", build_opts = c("--no-resave-data", "--no-manual"))
 ```
 
 # Introduction


### PR DESCRIPTION
As I write this, I realise it's probably no longer necessary now that it's accepted by BioC.
But here it is in any case. 
Without it, the `vignette("Introduction", package = "CellBench")` command will fail (my n=1 self-study found this results in confusion).

I guess, ultimately, you may now just want to update the installation instructions to install from BioC.